### PR TITLE
Fix syntax error in dict definition

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -15,7 +15,7 @@
 """
 
 settings = {
-    "api_subkey" = "", # API key for Azure Cognitive Services
+    "api_subkey": "", # API key for Azure Cognitive Services
     "pageurl": "https://google.com/recaptcha/api2/demo",   # ReCAPTCHA pageurl
     "sitekey": "6Le-wvkSAAAAAPBMRTvw0Q4Muexq9bi0DJwx_mJ-", # ReCAPTCHA sitekey
     "proxy_source": 


### PR DESCRIPTION
flake8 testing of https://github.com/mikeyy/nonoCAPTCHA on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./config.example.py:18:18: E999 SyntaxError: invalid syntax
    "api_subkey" = "", # API key for Azure Cognitive Services
                 ^
1     E999 SyntaxError: invalid syntax
1
```