### PR TITLE
small fixes

### DIFF
--- a/nonocaptcha/__init__.py
+++ b/nonocaptcha/__init__.py
@@ -4,8 +4,6 @@
 import os.path
 import sys
 
-from nonocaptcha.solver import Solver
-
 version_info = (1, 7, 7)
 __version__ = "{}.{}.{}".format(*version_info)
 
@@ -34,7 +32,6 @@ __all__ = (
     "settings",
     "package_dir",
     "package_info",
-    "Solver",
 )
 
 sys.path.append(os.getcwd())

--- a/nonocaptcha/__init__.py
+++ b/nonocaptcha/__init__.py
@@ -34,12 +34,14 @@ __all__ = (
     "package_info",
 )
 
-sys.path.append(os.getcwd())
+path = os.getcwd()
+sys.path.append(path)
 package_dir = os.path.dirname(os.path.abspath(__file__))
+config_dir = os.path.dirname(path)
 
 try:
     import yaml
-    with open(f"{package_dir}/nonocaptcha.yaml", "r") as f:
+    with open(os.path.join(config_dir, "nonocaptcha.yaml"), "r") as f:
         settings = yaml.load(f)
 except FileNotFoundError:
     print(

--- a/nonocaptcha/__init__.py
+++ b/nonocaptcha/__init__.py
@@ -4,6 +4,8 @@
 import os.path
 import sys
 
+from nonocaptcha.solver import Solver
+
 version_info = (1, 7, 7)
 __version__ = "{}.{}.{}".format(*version_info)
 
@@ -29,6 +31,10 @@ __all__ = (
     "__maintainer__",
     "__version__",
     "version_info",
+    "settings",
+    "package_dir",
+    "package_info",
+    "Solver",
 )
 
 sys.path.append(os.getcwd())
@@ -36,8 +42,7 @@ package_dir = os.path.dirname(os.path.abspath(__file__))
 
 try:
     import yaml
-
-    with open("nonocaptcha.yaml", "r") as f:
+    with open(f"{package_dir}/nonocaptcha.yaml", "r") as f:
         settings = yaml.load(f)
 except FileNotFoundError:
     print(

--- a/nonocaptcha/base.py
+++ b/nonocaptcha/base.py
@@ -38,7 +38,7 @@ class Base(Clicker):
     speech_service = settings["speech"]["service"]
     deface_data = os.path.join(package_dir, settings["data"]["deface_html"])
     jquery_data = os.path.join(package_dir, settings["data"]["jquery"])
-    override_data = os.path.join(package_dir, settings["data"]["override_js"])
+    override_data = os.path.join(package_dir, settings["data"]["override"])
 
     async def get_frames(self):
         self.checkbox_frame = next(

--- a/nonocaptcha/proxy.py
+++ b/nonocaptcha/proxy.py
@@ -26,6 +26,10 @@ class Proxy(Model):
     last_used = IntegerField(default=0)
     last_banned = IntegerField(default=0)
 
+    def __repr__(self):
+        return f'Proxy(ip={self.proxy}, active={self.active}, alive={self.alive}, last_used={self.last_used} '\
+            f'last_banned={self.last_banned})'
+
 
 # import os; if os.path.exists(database_filename): os.remove(database_filename)
 init_db(database_filename)

--- a/nonocaptcha/proxy.py
+++ b/nonocaptcha/proxy.py
@@ -27,8 +27,9 @@ class Proxy(Model):
     last_banned = IntegerField(default=0)
 
     def __repr__(self):
-        return f'Proxy(ip={self.proxy}, active={self.active}, alive={self.alive}, ' \
-               f'last_used={self.last_used} last_banned={self.last_banned})'
+        return f'Proxy(ip={self.proxy}, active={self.active}, '\
+            f'alive={self.alive}, last_used={self.last_used}, ' \
+            f'last_banned={self.last_banned})'
 
 
 # import os; if os.path.exists(database_filename): os.remove(database_filename)

--- a/nonocaptcha/proxy.py
+++ b/nonocaptcha/proxy.py
@@ -27,8 +27,8 @@ class Proxy(Model):
     last_banned = IntegerField(default=0)
 
     def __repr__(self):
-        return f'Proxy(ip={self.proxy}, active={self.active}, alive={self.alive}, last_used={self.last_used} '\
-            f'last_banned={self.last_banned})'
+        return f'Proxy(ip={self.proxy}, active={self.active}, alive={self.alive}, ' \
+               f'last_used={self.last_used} last_banned={self.last_banned})'
 
 
 # import os; if os.path.exists(database_filename): os.remove(database_filename)


### PR DESCRIPTION
the additions to `__all__` means that Solver gets imported when you do a 

`from nonocaptcha import *` (<-- bad practise but why not support it)

previously run.py expected the config file to be in the examples folder, so I changed a relative path to an absolute one. the repr is just for debugging in the future